### PR TITLE
fix: importing of packages that start from '@'

### DIFF
--- a/lib/commands/install/package-argument-parser.js
+++ b/lib/commands/install/package-argument-parser.js
@@ -42,16 +42,17 @@ class PackageArgumentParser {
   }
 
   parseVersioned(argument) {
-    let split = argument.split('@');
+    let versionIndex = argument.lastIndexOf('@')
+    
     return {
       argument: argument,
-      name: split[0],
-      version: split[1]
+      name: argument.substr(0,versionIndex),
+      version: argument.substr(versionIndex+1)
     };
   }
 
   hasVersion(argument) {
-    return argument.indexOf('@') > -1;
+    return argument.indexOf('@') > 0;
   }
 
   isGitUrl(argument) {


### PR DESCRIPTION
packages with names like @aspnet/signalr-client were treated like versioned